### PR TITLE
remove fgos.jl

### DIFF
--- a/src/RoME.jl
+++ b/src/RoME.jl
@@ -275,8 +275,6 @@ include("FactorGraphAnalysisTools.jl")
 include("WheeledRobotUtils.jl")
 include("NavigationSystem.jl")
 
-include("fgos.jl")
-
 # include("dev/ISAMRemoteSolve.jl")
 
 

--- a/src/fgos.jl
+++ b/src/fgos.jl
@@ -1,8 +1,0 @@
-# overload for new types available via RoME
-
-function convert{PT <: PackedInferenceType, T <: FunctorInferenceType}(::Type{PT}, ::T)
-  eval(parse("$(T.name.module).Packed$(T.name.name)"))
-end
-function convert{T <: FunctorInferenceType, PT <: PackedInferenceType}(::Type{T}, ::PT)
-  eval(parse("$(PT.name.module).$(string(PT.name.name)[7:end])"))
-end


### PR DESCRIPTION
with a non-eval implementation in IncrementalInference.jl (https://github.com/dehann/IncrementalInference.jl/pull/52) this can avoid overwriting these

seems to work, at least locally running the tests of the two packages when on both these branches